### PR TITLE
add shuffle to team data

### DIFF
--- a/texts/team/team-data.md
+++ b/texts/team/team-data.md
@@ -9,6 +9,8 @@ options:
   has-readmore: true
   has-socials: true
 
+  shuffle: true
+
   card-modal: true
   card-modal-config:
     full-screen: false


### PR DESCRIPTION
Activates  feat shuffle of multi-site-app. Here only activates shuffle to team cards (@JazzyPierrot talked about that a while ago)

See https://github.com/multi-coop/multi-site-app/pull/16