### PR TITLE
change color

### DIFF
--- a/config/global.md
+++ b/config/global.md
@@ -16,15 +16,16 @@ legal: ./config/legal.md
 #   images: ./images
 #   data: ./data
 
+custom_colors: true
 colors:
-  loading_color: #6fdcbf
-  primary: #bc85ff
-  accent: #572a99
-  secondary: #6fdcbf
-  info: #53657D
-  warning: #ff9947
-  error: #D1335B
-  success: #03BD5B
+  primary: '#037988'
+  # loading_color: '#6fdcbf'
+  # accent: '#572a99'
+  # secondary: '#6fdcbf'
+  # info: '#53657D'
+  # warning: '#ff9947'
+  # error: '#D1335B'
+  # success: '#03BD5B'
 
 ---
 


### PR DESCRIPTION
spéciale dédicace @pierrecamilleri qui n'en peut plus du violet de notre site

J'ai mis en place [qqs lignes de css dynamique](https://github.com/multi-coop/multi-site-app/commit/84914a749b365a4f1d9e2cb6031fa18319c966ad) qui permettent de surcharger les couleurs par défaut de Bulma (le f*****g violoet donc) pour les remplacer par la couleur primaire de notre choix, cad une couleur qu'on peut indiquer dans le fichier `config/global.md`

Pour info c toujours dans le cadre de mon boulot sur la doc de Gitribute que j'ai voulu avoir une couleur principale différente, et comme ça manquait, qu'il y avait déjà un ticket dessus et que ct pas long...

J'ai aussi ajouté un switch de sécurité, la clé `custom_colors` qui doit être en `true` pour appliquer les couleurs custom sur le site

T'en penses quoi Pierre, tu as une couleur préférée ? https://htmlcolorcodes.com/

<img width="873" alt="Capture d’écran 2022-07-09 à 16 25 16" src="https://user-images.githubusercontent.com/21986727/178109994-45908ac9-3ecf-4258-8eb5-d69e126d7b96.png">


<img width="671" alt="Capture d’écran 2022-07-09 à 16 29 38" src="https://user-images.githubusercontent.com/21986727/178110142-9a569679-5824-47c2-92cc-5172cd5ea9a5.png">

<img width="691" alt="Capture d’écran 2022-07-09 à 16 31 13" src="https://user-images.githubusercontent.com/21986727/178110177-b99f0085-dea1-40a1-a83c-69ca0363cbaa.png">

<img width="674" alt="Capture d’écran 2022-07-09 à 16 33 28" src="https://user-images.githubusercontent.com/21986727/178110260-5b938d66-3750-4e09-be8e-e70aace0b5fa.png">

