### PR TITLE
fix(routes): home : add description in fr & en (for meta tags)

### DIFF
--- a/config/routes.md
+++ b/config/routes.md
@@ -7,8 +7,8 @@ routes:
     options:
       hero: true
       description:
-        fr: Coopérative multi-disciplinaire. Nous concevons et développons des services numériques d’intérêt général.
-        en: Multi-disciplinary cooperative. We design and develop digital services for the general interest.
+        fr: Coopérative qui conçois et développe des services numériques d’intérêt général.
+        en: Cooperative that designs and develops digital services for the general interest.
     sections: 
       - name: logo
         component: TextComponent

--- a/config/routes.md
+++ b/config/routes.md
@@ -7,7 +7,7 @@ routes:
     options:
       hero: true
       description:
-        fr: Coopérative qui conçois et développe des services numériques d’intérêt général.
+        fr: Coopérative qui conçoit et développe des services numériques d’intérêt général.
         en: Cooperative that designs and develops digital services for the general interest.
     sections: 
       - name: logo

--- a/config/routes.md
+++ b/config/routes.md
@@ -8,7 +8,7 @@ routes:
       hero: true
       description:
         fr: Coopérative qui conçoit et développe des services numériques d’intérêt général.
-        en: Cooperative that designs and develops digital services for the public interest.
+        en: Cooperative that designs and develops digital services in the public interest.
     sections: 
       - name: logo
         component: TextComponent

--- a/config/routes.md
+++ b/config/routes.md
@@ -6,6 +6,9 @@ routes:
     url: /
     options:
       hero: true
+      description:
+        fr: Coopérative multi-disciplinaire. Nous concevons et développons des services numériques d’intérêt général.
+        en: Multi-disciplinary cooperative. We design and develop digital services for the general interest.
     sections: 
       - name: logo
         component: TextComponent

--- a/config/routes.md
+++ b/config/routes.md
@@ -8,7 +8,7 @@ routes:
       hero: true
       description:
         fr: Coopérative qui conçoit et développe des services numériques d’intérêt général.
-        en: Cooperative that designs and develops digital services for the general interest.
+        en: Cooperative that designs and develops digital services for the public interest.
     sections: 
       - name: logo
         component: TextComponent


### PR DESCRIPTION
See #90

https://github.com/multi-coop/multi-site-app/blob/3f41a6d85e726da253d52f50ab8abf0bd867a484/pages/index.vue#L401

j'ai pris le texte ici : https://www.multi.coop/cooperative?locale=fr
> 🚀 multi est une coopérative multi-disciplinaire. Nous concevons et développons des outils numériques d’intérêt général.

Texte alternatif : https://www.multi.coop
> La coopérative multi contribue à développer des communs numériques et des services associés, en regroupant une communauté de professionnel·le·s oeuvrant pour un numérique d’intérêt général.